### PR TITLE
changed to published view of gsheets

### DIFF
--- a/source/_templates/hs onix template eib 6809 no adp.rst
+++ b/source/_templates/hs onix template eib 6809 no adp.rst
@@ -53,7 +53,7 @@
 Other combinations
 ------------------
 
-To construct other channel maps, take a look at the channel mapping table and connector pinout.
+To construct other channel maps, navigate through the `channel mapping table and connector pinout document <https://docs.google.com/spreadsheets/d/e/2PACX-1vSxEZVG5xytX9CU5a87evB-YSvePfsPWiUGv_nH_SoK7Be4nRgFMId30PxKsUkr2QmLoIl2BF-KabnA/pubhtml>`__.
 
 ..  raw:: html
 

--- a/source/_templates/hs onix template eib 6813 adp 7200.rst
+++ b/source/_templates/hs onix template eib 6813 adp 7200.rst
@@ -111,7 +111,7 @@
 Other combinations
 ------------------
 
-To construct other channel maps, take a look at the channel mapping table and connector pinout.
+To construct other channel maps, navigate through the `channel mapping table and connector pinout document <https://docs.google.com/spreadsheets/d/e/2PACX-1vSxEZVG5xytX9CU5a87evB-YSvePfsPWiUGv_nH_SoK7Be4nRgFMId30PxKsUkr2QmLoIl2BF-KabnA/pubhtml>`__.
 
 ..  raw:: html
 

--- a/source/_templates/hs onix template no eib no adp.rst
+++ b/source/_templates/hs onix template no eib no adp.rst
@@ -32,7 +32,7 @@
 Other combinations
 ------------------
 
-To construct other channel maps, take a look at the channel mapping table and connector pinout.
+To construct other channel maps, navigate through the `channel mapping table and connector pinout document <https://docs.google.com/spreadsheets/d/e/2PACX-1vSxEZVG5xytX9CU5a87evB-YSvePfsPWiUGv_nH_SoK7Be4nRgFMId30PxKsUkr2QmLoIl2BF-KabnA/pubhtml>`__.
 
 ..  raw:: html
 

--- a/source/_templates/hs spi template eib 6809 no adp.rst
+++ b/source/_templates/hs spi template eib 6809 no adp.rst
@@ -64,7 +64,7 @@
 Other combinations
 ------------------
 
-To construct other channel maps, take a look at the channel mapping table and connector pinout.
+To construct other channel maps, navigate through the `channel mapping table and connector pinout document <https://docs.google.com/spreadsheets/d/e/2PACX-1vS1gLC6sHhH6Xbcib5xx0Up7nUkKYEuGhZ0BLtfBYLqsw_X___o-2niKnuLJcrOKamIKYIWAuOcH3Pl/pubhtml>`__.
 
 ..  raw:: html
 

--- a/source/_templates/hs spi template eib 6813 adp 7200.rst
+++ b/source/_templates/hs spi template eib 6813 adp 7200.rst
@@ -82,7 +82,7 @@
 Other combinations
 ------------------
 
-To construct other channel maps, take a look at the channel mapping table and connector pinout.
+To construct other channel maps, navigate through the `channel mapping table and connector pinout document <https://docs.google.com/spreadsheets/d/e/2PACX-1vS1gLC6sHhH6Xbcib5xx0Up7nUkKYEuGhZ0BLtfBYLqsw_X___o-2niKnuLJcrOKamIKYIWAuOcH3Pl/pubhtml>`__.
 
 ..  raw:: html
 

--- a/source/_templates/hs spi template no eib no adp.rst
+++ b/source/_templates/hs spi template no eib no adp.rst
@@ -42,7 +42,7 @@
 Other combinations
 ------------------
 
-To construct other channel maps, take a look at the channel mapping table and connector pinout.
+To construct other channel maps, navigate through the `channel mapping table and connector pinout document <https://docs.google.com/spreadsheets/d/e/2PACX-1vS1gLC6sHhH6Xbcib5xx0Up7nUkKYEuGhZ0BLtfBYLqsw_X___o-2niKnuLJcrOKamIKYIWAuOcH3Pl/pubhtml>`__.
 
 ..  raw:: html
 


### PR DESCRIPTION
This addresses part of #14 and it looks like it might fix #13 

I'm still not satisfied with the inclusion of the channel mapping table overall, because it should be on a page-by-page basis, not the same across all pages (which is now the case because it is in the templates). We can use the gid property of the embed link to point to the appropriate page. I will write this as a new issue because I still think that the table should be there in some shape or form, and we can refine on a second pass.